### PR TITLE
add map query to DHT

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ There are many ways that you can contribute.
 - Making a [donation](https://github.com/larteyoh/testshop#donations) to fund the development of the project
 - Help us [test](#testing) the software and report any bugs or vulnerabilities found in the code as a GitHub [issue](https://github.com/larteyoh/testshop/issues)
 - Sharing this project so more people can learn about its existence
-- Support the neroshop network by running your own neroshop node
+- Support the neroshop network by running your own neroshop node or volunteering to become a bootstrap node
 
 **Please refer to [the wiki](https://github.com/larteyoh/testshop/wiki/FAQ#how-can-i-contribute-to-neroshop-if-i-dont-know-c-or-c) for more information on how to contribute.**
 
@@ -18,6 +18,7 @@ To run the GUI application, use the following command:
 ./neroshop
 ```
 By default, the GUI runs the daemon in a separate detached process so there's no need to worry about that unless you're using `neroshop-console`, but if you really need to observe what is going on behind the scenes, you can still launch the daemon in a separate tab or window within the terminal before launching the GUI application.
+
 The GUI should automatically detect whether the daemon is running in the background or not.
 
 **Both `neroshop` and `neroshop-console` cannot be opened simultaneously as the IPC server only accepts a single client connection at a time.**
@@ -77,8 +78,6 @@ To run a public node, you must include the `--public` flag when starting the dae
 ./neromon --public
 ```
 
-**Be sure that port forwarding is enabled on your machine in order for other nodes to find your node.**
-
-**Edit: As of May 26 2023, automatic port forwarding now works on UPnP-enabled routers and the `--public` flag is no longer required to participate in the neroshop DHT network.**
+**Be sure that port forwarding is enabled on your machine in order for other nodes to find your node on port `50881`.**
 
 Another thing: You can also run a public RPC server by combining the `--rpc` and `--public` flags.

--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ The name _neroshop_ is a combination of the words _nero_, which is Italian for _
 - [ ] Subaddress generator for direct payments without an escrow (a unique subaddress will be generated from a seller's synced wallet account for each order placed by a customer)
 - [x] Built-in Monero wallet with basic functionalities (transaction history, send, and receive)
 - [x] Option to run a local Monero node or connect to remote Monero nodes
-- [x] Payment address QR codes containing Monero URIs
+- [ ] Payment address QR codes containing Monero URIs
 - [ ] Option to choose between sending funds directly to a seller or by using a multisignature escrow.
 - [ ] Native Tor and I2P support (tor daemon will be bundled with each release and i2pd will be built-in)
 - [x] Seller reputation system
 - [x] Product rating system
 - [ ] Wishlists
-- [ ] Built-in SQLite-powered search engine that can find any products or sellers
+- [x] Built-in SQLite-powered search engine that can find any products or sellers
 - [ ] Full-featured and user-friendly GUI application (WIP)
 
 ## Building neroshop

--- a/src/core/protocol/messages/msgpack.cpp
+++ b/src/core/protocol/messages/msgpack.cpp
@@ -287,6 +287,22 @@ std::vector<uint8_t> neroshop::msgpack::process(const std::vector<uint8_t>& requ
         }
     }
     //-----------------------------------------------------
+    if(method == "map") {
+        assert(request_object["args"].is_object());
+        auto params_object = request_object["args"];
+        assert(params_object["key"].is_string());
+        std::string key = params_object["key"];
+        assert(params_object["value"].is_string());
+        std::string value = params_object["value"];
+        
+        // Store indexing data in database on receiving a "map" request
+        node.map(key, value);
+    
+        // Return success response
+        response_object["version"] = std::string(NEROSHOP_DHT_VERSION);
+        response_object["response"]["id"] = node.get_id();
+    }
+    //-----------------------------------------------------
     if(method == "search" && ipc_mode) { // For value-based DHT lookups, but only works on data that your node has
         assert(request_object["args"].is_object());
         auto params_object = request_object["args"];

--- a/src/core/protocol/p2p/node.hpp
+++ b/src/core/protocol/p2p/node.hpp
@@ -76,17 +76,17 @@ public:
     std::string send_get(const std::string& key);
     std::string send_find_value(const std::string& key);
     void send_remove(const std::string& key);
+    void send_map(const std::string& address, int port); // Distributes indexing data to a single node
     // announce_peer, get_peers are specific to Bittorent and are not used in standard Kademlia
     //---------------------------------------------------
     std::vector<Node*> lookup(const std::string& key); // In Kademlia, the primary purpose of the lookup function is to find the nodes responsible for storing a particular key in the DHT, rather than retrieving the actual value of the key. The lookup function helps in locating the nodes that are likely to have the key or be able to provide information about it.
-    //---------------------------------------------------    
+    //---------------------------------------------------
     void join(/*std::function<void()> on_join_callback*/); // Sends a join message to the bootstrap peer to join the network
     void run(); // Main loop that listens for incoming messages
     void run_optimized(); // Uses less CPU than run but slower to process requests
     void periodic_check();
     void periodic_refresh(); // Periodic republishing
     void republish();
-    void republish(const std::string& address, int port); // Republishes data to a single node
     bool validate(const std::string& key, const std::string& value); // Validates data before storing it
     //---------------------------------------------------
     void on_ping_callback(const std::vector<uint8_t>& buffer, const struct sockaddr_in& client_addr);


### PR DESCRIPTION
* whenever a new node contacts your node, your node will send the new node a `map` request query with all your node's key-value pair data as the arguments so that it can map certain keywords/search terms based on the value to DHT keys, which will allow the new node to efficiently search for products easily without having to store and maintain a copy of the data in their hash table.