### PR TITLE
rewrite create_order and create create_order_batch func

### DIFF
--- a/qml/components/CatalogGrid.qml
+++ b/qml/components/CatalogGrid.qml
@@ -265,8 +265,9 @@ GridView {
                 id: starsRow
                 Layout.alignment: (!settingsDialog.gridDetailsAlignCenter) ? 0 : Qt.AlignHCenter
                 //spacing: 5
-                property real avg_stars: Backend.getProductAverageStars(modelData.product_uuid)
-                property int star_ratings_count: Backend.getProductStarCount(modelData.product_uuid)
+                property var product_ratings_model: Backend.getProductRatings(modelData.product_uuid)
+                property real avg_stars: Backend.getProductAverageStars(starsRow.product_ratings_model)
+                property int star_ratings_count: Backend.getProductStarCount(starsRow.product_ratings_model)
                 //Component.onCompleted: console.log("avg stars", starsRow.avg_stars)
                 Repeater {
                     model: 5

--- a/src/core/order.hpp
+++ b/src/core/order.hpp
@@ -83,6 +83,7 @@ public:
 	    const std::vector<std::tuple<std::string, int, std::string>>& items);
 	~Order();
 	void create_order(const neroshop::Cart& cart, const std::string& shipping_address);
+	void create_order_batch(const neroshop::Cart& cart, const std::string& shipping_address);
 	void cancel_order(); // revoke the order
 	void change_order(); // edit the order info such as: shipping_address, contact_info, removing individual items from order or item_qty, or adding a note, applying coupon
 	void download_order(); // order details will be in JSON format

--- a/src/core/protocol/p2p/serializer.cpp
+++ b/src/core/protocol/p2p/serializer.cpp
@@ -185,7 +185,7 @@ std::pair<std::string, std::string/*std::vector<uint8_t>*/> neroshop::Serializer
         json_object["notes"] = order.get_notes(); // TODO: encrypt notes
         for(const auto& item : order.get_items()) {
             nlohmann::json order_item_obj = {};
-            order_item_obj["product_id"] = std::get<0>(item);
+            order_item_obj["listing_key"] = std::get<0>(item);
             order_item_obj["quantity"] = std::get<1>(item);
             order_item_obj["seller_id"] = std::get<2>(item);
             json_object["items"].push_back(order_item_obj); // order_items // TODO: encrypt order items
@@ -370,10 +370,10 @@ std::shared_ptr<neroshop::Object> neroshop::Serializer::deserialize(const std::p
         assert(value["items"].is_array()); // items should be an array of objects
         std::vector<std::tuple<std::string, int, std::string>> order_items;
         for (const auto& item : value["items"]) {
-            std::string product_id = item["product_id"].get<std::string>();
+            std::string listing_id = item["listing_key"].get<std::string>();
             int quantity = item["quantity"].get<int>();
             std::string seller_id = item["seller_id"].get<std::string>();
-            order_items.emplace_back(product_id, quantity, seller_id);
+            order_items.emplace_back(listing_id, quantity, seller_id);
         }
         order.set_items(order_items);
         variant_object = std::make_shared<Object>(order);

--- a/src/core/user.cpp
+++ b/src/core/user.cpp
@@ -93,9 +93,6 @@ void neroshop::User::rate_seller(const std::string& seller_id, int score, const 
     client->put(key, value, response);
     std::cout << "Received response: " << response << "\n";
 } 
-// int seller_id = 2;
-// user->rate_seller(seller_id, 1, "This seller rocks!");
-// user->rate_seller(seller_id, 0, "This seller sucks!");
 ////////////////////
 ////////////////////
 void neroshop::User::rate_item(const std::string& product_id, int stars, const std::string& comments, const std::string& signature) { // perfected 99%!!!
@@ -176,7 +173,6 @@ void neroshop::User::rate_item(const std::string& product_id, int stars, const s
     client->put(key, value, response);
     std::cout << "Received response: " << response << "\n";
 } 
-// user->rate_item(ball.get_id(), 5, "Definitely not a Dragon ball!");
 ////////////////////
 ////////////////////
 // account-related stuff here

--- a/src/gui/backend.hpp
+++ b/src/gui/backend.hpp
@@ -81,8 +81,11 @@ public:
     Q_INVOKABLE bool saveProductImage(const QString& fileName, const QString& listingKey);
     Q_INVOKABLE bool saveProductThumbnail(const QString& fileName, const QString& listingKey);
 
+    Q_INVOKABLE int getProductStarCount(const QVariantList& product_ratings);
     Q_INVOKABLE int getProductStarCount(const QString& product_id); // getProductRatingsCount
+    Q_INVOKABLE int getProductStarCount(const QVariantList& product_ratings, int star_number);
     Q_INVOKABLE int getProductStarCount(const QString& product_id, int star_number);
+    Q_INVOKABLE float getProductAverageStars(const QVariantList& product_ratings);
     Q_INVOKABLE float getProductAverageStars(const QString& product_id);
     
     Q_INVOKABLE int getSellerGoodRatings(const QVariantList& seller_ratings);


### PR DESCRIPTION
* create alternative `Backend::getProduct*` functions to reduce number of `get` requests
* change order `product_id` field to `listing_key`
* add `seller_id` column back in cart_item table in SQLite
* rewrite `create_order` and create `create_order_batch`
* implement eventual removal/"distributed cleanup" by propagating expired data to all nodes in the network in order for it to be removed from their local hash tables (WARNING: This can cause some major issues unless managed correctly)
* `on_ping`: prevent the bootstrap node from being stored in the routing table when 