### PR TITLE
add 'send to many' function

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "external/monero-cpp"]
 	path = external/monero-cpp
-	url = https://github.com/monero-ecosystem/monero-cpp.git
+	url = https://github.com/woodser/monero-cpp.git
 [submodule "external/QR-Code-generator"]
 	path = external/QR-Code-generator
 	url = https://github.com/nayuki/QR-Code-generator.git

--- a/qml/pages/subpages/WalletPage.qml
+++ b/qml/pages/subpages/WalletPage.qml
@@ -94,7 +94,7 @@ Page {
                     TextField {
                         id: balanceLockedText
                         visible: (settingsDialog.balanceDisplay == 2) ? false : true
-                        property double balance: !Wallet.opened ? 0.000000000000 : Wallet.balanceLocked
+                        property double balance: !Wallet.opened || (Wallet.balanceLocked == Wallet.balanceUnlocked) ? 0.000000000000 : Wallet.balanceLocked - Wallet.balanceUnlocked
                         text: balance.toFixed(settingsDialog.balanceAmountPrecision)
                         font.bold: !balanceUnlockedText.visible ? true : false
                         font.pointSize: !balanceUnlockedText.visible ? 48 : 24

--- a/src/core/wallet.hpp
+++ b/src/core/wallet.hpp
@@ -56,7 +56,8 @@ public:
     monero::monero_subaddress create_subaddress(unsigned int account_idx, const std::string & label = "") const; // generates a new subaddress from main account // monero addresses start with 4 or 8
     
     void transfer(const std::string& address, double amount); // "transfer" will be used for sending refunds
-    void sweep_all(const std::string& address); // sends entire balance, including dust to an address // "sweep_all <address>"
+    void transfer(const std::vector<std::pair<std::string, double>>& payment_addresses);
+    
     std::string address_new() const; // this function has been replaced by create_subaddress() and is deprecated. Will be removed soon
     unsigned int address_book_add(const std::string& address, std::string description = ""); // "address_book add <address> <description>"
     void address_book_delete(unsigned int index); // "address_book delete 0"  

--- a/src/gui/wallet_controller.hpp
+++ b/src/gui/wallet_controller.hpp
@@ -25,15 +25,7 @@ class WalletController : public QObject, public monero_wallet_listener
     Q_PROPERTY(double balanceUnlocked READ getBalanceUnlocked NOTIFY balanceChanged);
     Q_PROPERTY(QVariantList transfers READ getTransfers NOTIFY transfersChanged);
     //Q_PROPERTY(<type> <variable_name> READ <get_function_name> NOTIFY)
-public:    
-    // I don't know how to use or compare enums in QML. It never works, but oh well :|
-    enum KeyfileStatus {
-        KeyfileStatus_Ok = 0,
-        KeyfileStatus_Wrong_Password,
-        KeyfileStatus_No_Matching_Passwords,
-        KeyfileStatus_Exists,
-    };
-    Q_ENUM(KeyfileStatus)
+public:
     // functions (for use in QML)
     Q_INVOKABLE int createRandomWallet(const QString& password, const QString& confirm_pwd, const QString& path);
     Q_INVOKABLE int restoreFromSeed(const QString& seed);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,7 +17,7 @@ set(neroshop_database_src
 
 set(neroshop_network_src 
     ${NEROSHOP_CORE_SRC_DIR}/network/i2p.cpp 
-    ${NEROSHOP_CORE_SRC_DIR}/network/tor.cpp
+    #[[${NEROSHOP_CORE_SRC_DIR}/network/tor.cpp]]
 )
 
 set(neroshop_price_src 
@@ -429,7 +429,7 @@ set(lua_src liblua.a)
 # network_test
 set(test_network "network_test")
 add_executable(${test_network} network_test.cpp ${neroshop_srcs})
-target_link_libraries(${test_network} ${monero_cpp_src} ${sqlite_src} ${qr_code_generator_src} ${raft_src} ${libuv_src} ${curl_src} ${monero_src} ${lua_src})
+target_link_libraries(${test_network} ${monero_cpp_src} ${sqlite_src} ${qr_code_generator_src} ${raft_src} ${curl_src} ${monero_src} ${lua_src})
 # network_uv test
 #[[set(test_network_uv "network_uv_test")
 add_executable(${test_network_uv} network_test_uv.cpp ${neroshop_srcs})
@@ -437,30 +437,30 @@ target_link_libraries(${test_network_uv} ${monero_cpp_src} ${sqlite_src} ${qr_co
 # utility test
 set(test_utility "utility_test")
 add_executable(${test_utility} utility_test.cpp ${neroshop_srcs})
-target_link_libraries(${test_utility} ${monero_cpp_src} ${sqlite_src} ${qr_code_generator_src} ${raft_src} ${libuv_src} ${curl_src} ${monero_src} ${lua_src})
+target_link_libraries(${test_utility} ${monero_cpp_src} ${sqlite_src} ${qr_code_generator_src} ${raft_src} ${curl_src} ${monero_src} ${lua_src})
 # auth_test
 set(test_auth "auth_test")
 add_executable(${test_auth} auth_test.cpp ${neroshop_srcs})
-target_link_libraries(${test_auth} ${monero_cpp_src} ${sqlite_src} ${qr_code_generator_src} ${raft_src} ${libuv_src} ${curl_src} ${monero_src} ${lua_src})
+target_link_libraries(${test_auth} ${monero_cpp_src} ${sqlite_src} ${qr_code_generator_src} ${raft_src} ${curl_src} ${monero_src} ${lua_src})
 # uuid_test
 set(test_uuid "uuid_test")
 add_executable(${test_uuid} uuid_test.cpp)
 # qr_code_test
 set(test_qr_code "qr_test")
 add_executable(${test_qr_code} qr_test.cpp ${neroshop_srcs})
-target_link_libraries(${test_qr_code} ${monero_cpp_src} ${sqlite_src} ${qr_code_generator_src} ${raft_src} ${libuv_src} ${curl_src} ${monero_src} ${lua_src})
+target_link_libraries(${test_qr_code} ${monero_cpp_src} ${sqlite_src} ${qr_code_generator_src} ${raft_src} ${curl_src} ${monero_src} ${lua_src})
 # encryption_test
 set(test_crypt "encryption_test")
 add_executable(${test_crypt} encryption_test.cpp ${neroshop_srcs})
-target_link_libraries(${test_crypt} ${monero_cpp_src} ${sqlite_src} ${qr_code_generator_src} ${raft_src} ${libuv_src} ${curl_src} ${monero_src} ${lua_src})
+target_link_libraries(${test_crypt} ${monero_cpp_src} ${sqlite_src} ${qr_code_generator_src} ${raft_src} ${curl_src} ${monero_src} ${lua_src})
 # signing_test
 set(test_sign "signing_test")
 add_executable(${test_sign} signing_test.cpp ${neroshop_srcs})
-target_link_libraries(${test_sign} ${monero_cpp_src} ${sqlite_src} ${qr_code_generator_src} ${raft_src} ${libuv_src} ${curl_src} ${monero_src} ${lua_src})
+target_link_libraries(${test_sign} ${monero_cpp_src} ${sqlite_src} ${qr_code_generator_src} ${raft_src} ${curl_src} ${monero_src} ${lua_src})
 # sign_verify_test
 set(test_sign_verify "sign_verify_test")
 add_executable(${test_sign_verify} sign_verify_test.cpp ${neroshop_srcs})
-target_link_libraries(${test_sign_verify} ${monero_cpp_src} ${sqlite_src} ${qr_code_generator_src} ${raft_src} ${libuv_src} ${curl_src} ${monero_src} ${lua_src})
+target_link_libraries(${test_sign_verify} ${monero_cpp_src} ${sqlite_src} ${qr_code_generator_src} ${raft_src} ${curl_src} ${monero_src} ${lua_src})
 # Qt gui_test
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
@@ -471,17 +471,21 @@ add_executable(${test_gui_qt} main_window.ui main_window.cpp gui_qt_test.cpp ${n
 #[[target_]] 
 include_directories(#[[${test_gui_qt} ]] /usr/include/x86_64-linux-gnu/qt5/ /usr/include/x86_64-linux-gnu/qt5/QtWidgets/)
 #target_compile_definitions(${test_gui_qt} PRIVATE )
-target_link_libraries(${test_gui_qt} ${monero_cpp_src} ${sqlite_src} ${qr_code_generator_src} ${raft_src} ${libuv_src} ${curl_src} ${monero_src} ${lua_src})
+target_link_libraries(${test_gui_qt} ${monero_cpp_src} ${sqlite_src} ${qr_code_generator_src} ${raft_src} ${curl_src} ${monero_src} ${lua_src})
 
 # escrow_test
 set(test_escrow "escrow_test")
 add_executable(${test_escrow} escrow.cpp ${neroshop_srcs})
-target_link_libraries(${test_escrow} ${monero_cpp_src} ${sqlite_src} ${qr_code_generator_src} ${raft_src} ${libuv_src} ${curl_src} ${monero_src} ${lua_src})
+target_link_libraries(${test_escrow} ${monero_cpp_src} ${sqlite_src} ${qr_code_generator_src} ${raft_src} ${curl_src} ${monero_src} ${lua_src})
+
+set(test_wallet "wallet_test")
+add_executable(${test_wallet} wallet_test.cpp ${neroshop_srcs})
+target_link_libraries(${test_wallet} ${monero_cpp_src} ${sqlite_src} ${qr_code_generator_src} ${raft_src} ${curl_src} ${monero_src} ${lua_src})
 
 #[[
 set(test_ "")
 add_executable(${test_} .cpp ${neroshop_srcs})
-target_link_libraries(${test_} ${monero_cpp_src} ${sqlite_src} ${qr_code_generator_src} ${raft_src} ${libuv_src} ${curl_src} ${monero_src} ${lua_src})
+target_link_libraries(${test_} ${monero_cpp_src} ${sqlite_src} ${qr_code_generator_src} ${raft_src} ${curl_src} ${monero_src} ${lua_src})
 ]]
 
 ######################################
@@ -501,8 +505,11 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     target_link_libraries(${test_auth} ${posix_src})
     target_link_libraries(${test_qr_code} ${posix_src})
     target_link_libraries(${test_crypt} ${posix_src})
+    target_link_libraries(${test_sign} ${posix_src})
     target_link_libraries(${test_sign_verify} ${posix_src})
     target_link_libraries(${test_gui_qt} ${posix_src})
+    target_link_libraries(${test_escrow} ${posix_src})
+    target_link_libraries(${test_wallet} ${posix_src})
     #target_link_libraries(${test_} ${posix_src})
     find_package(X11 REQUIRED)
     if(X11_FOUND)

--- a/tests/wallet_test.cpp
+++ b/tests/wallet_test.cpp
@@ -1,0 +1,24 @@
+#include <unistd.h>
+#include "../src/core/wallet.hpp"
+
+int main() {
+    
+    neroshop::Wallet *wallet = new neroshop::Wallet();
+    wallet->create_random("", "", "random_wallet");
+    
+    // This isn't working??
+    wallet->daemon_connect_remote("node2.monerodevs.org", "38089");
+    
+    // Your vector of payment addresses
+    std::vector<std::pair<std::string, double>> payment_addresses = {
+        {"Address1", 1.0},
+        {"Address2", 0.5},
+        {"Address3", 0.25}
+    };
+    
+    sleep(900); // wait for node to finish syncing?
+    
+    wallet->transfer(payment_addresses);
+    
+    return 0;
+}


### PR DESCRIPTION
* add new `Wallet::transfer` function that sends to multiple destinations in a single transaction
* wallet (locked) balance is now displayed correctly 
    * locked balance includes both the unlocked balance and the incoming balance so we would subtract the unlocked balance from the locked balance to get only the incoming balance
* changed `monero-cpp` submodule link
* remove unnecessary `Wallet::sweep_all` function
* remove unused `KeyfileStatus` enum
* fix the `tests/` build (again - for the millionth time)