### PR TITLE
changes to protocol

### DIFF
--- a/src/core/protocol/messages/msgpack.cpp
+++ b/src/core/protocol/messages/msgpack.cpp
@@ -284,17 +284,6 @@ std::vector<uint8_t> neroshop::msgpack::process(const std::vector<uint8_t>& requ
         std::string key = params_object["key"];
         assert(params_object["value"].is_string());
         std::string value = params_object["value"];
-        assert(params_object["verified"].is_boolean());
-        bool verified = params_object["verified"].get<bool>();
-        
-        if(verified == false) {
-            code = static_cast<int>(KadResultCode::DataVerificationFailed);
-            response_object["error"]["code"] = code;
-            response_object["error"]["message"] = "Data verification failed";
-            response_object["tid"] = tid;
-            response = nlohmann::json::to_msgpack(response_object);
-            return response;
-        }
         
         // Send put messages to the closest nodes in your routing table (IPC mode)
         int put_messages_sent = node.send_put(key, value);

--- a/src/core/protocol/transport/client.cpp
+++ b/src/core/protocol/transport/client.cpp
@@ -239,9 +239,9 @@ void neroshop::Client::get(const std::string& key, std::string& reply) {
     }    
 }
 
-void neroshop::Client::set(const std::string& key, const std::string& value, bool verified, std::string& reply) {
+void neroshop::Client::set(const std::string& key, const std::string& value, std::string& reply) {
     // Send set - no id or tid required for IPC client requests. The DHT server will deal with that
-    nlohmann::json args_obj = { {"key", key}, {"value", value}, {"verified", verified} };
+    nlohmann::json args_obj = { {"key", key}, {"value", value} };
     nlohmann::json query_object = { {"version", std::string(NEROSHOP_DHT_VERSION)}, {"query", "set"}, {"args", args_obj}, {"tid", nullptr} };
     std::vector<uint8_t> packed_data = nlohmann::json::to_msgpack(query_object);
     send(packed_data);

--- a/src/core/protocol/transport/client.hpp
+++ b/src/core/protocol/transport/client.hpp
@@ -56,7 +56,7 @@ public:
 	// Interactions with the DHT node, which only exists on the client side via IPC server
 	void put(const std::string& key, const std::string& value, std::string& response);
 	void get(const std::string& key, std::string& response);
-	void set(const std::string& key, const std::string& value, bool verified, std::string& response);
+	void set(const std::string& key, const std::string& value, std::string& response);
 	void close(); // kills socket
 	void shutdown(); // shuts down connection (disconnects from server)
     void disconnect(); // breaks connection to server then closes the client socket // combination of shutdown() and close()


### PR DESCRIPTION
* any modifications applied to a listing is now **self-verified** on the **client** side, in addition to the usual verification done by peers in the network.
* checks for any mismatch between `metadata`, `id`, and `seller_id` when comparing the current and newest listing data sharing the same key.
* modified listing data is **re-signed** to reflect the recent changes.
* metadata is now validated in the `Node::validate()` function.