### PR TITLE
move wallet member to user class

### DIFF
--- a/src/core/protocol/p2p/node.cpp
+++ b/src/core/protocol/p2p/node.cpp
@@ -338,6 +338,13 @@ int neroshop::Node::set(const std::string& key, const std::string& value) {
                 if(rater_id != current_json["rater_id"].get<std::string>()) { std::cerr << "Rater ID mismatch\n"; return false; } // rater_id is immutable
             }
             
+            // Make sure the signature has been updated
+            if (json.contains("signature")) {
+                assert(json["signature"].is_string());
+                std::string signature = json["signature"].get<std::string>();
+                if(signature == current_json["signature"].get<std::string>()) { std::cerr << "Signature is outdated\n"; return false; }
+            }
+            
             // Compare dates of new data and old (pre-existing) data - untested
             if(json.contains("last_updated")) {
                 assert(json["last_updated"].is_string());

--- a/src/core/protocol/p2p/serializer.cpp
+++ b/src/core/protocol/p2p/serializer.cpp
@@ -461,7 +461,7 @@ std::pair<std::string, std::string> neroshop::Serializer::serialize(const User& 
     std::string key = neroshop_crypto::sha3_256(value);
     
     // Data verification tests
-    #ifdef NEROSHOP_DEBUG
+    #ifdef NEROSHOP_DEBUG0
     auto result = seller->get_wallet()->verify_message(user_id, signature);
     std::cout << "\033[1mverified: " << (result == 1 ? "\033[32mpass" : "\033[91mfail") << "\033[0m\n";
     assert(result == true);

--- a/src/core/seller.hpp
+++ b/src/core/seller.hpp
@@ -13,7 +13,6 @@
 namespace neroshop {
 
 // forward declarations
-class Wallet;
 class Product;
 class Image;
 
@@ -44,8 +43,6 @@ public:
 	void delist_item(const std::string& listing_key); // deletes an item from the inventory
 	// setters - item and inventory-related stuff
 	void set_stock_quantity(const std::string& listing_key, int quantity);
-	// setters - wallet-related stuff
-	void set_wallet(const neroshop::Wallet& wallet);// temporary - delete ASAP
 	// getters - seller rating system
 	unsigned int get_good_ratings() const; // returns the total number of good ratings given to this seller by their customers
 	unsigned int get_bad_ratings() const; // returns the total number of bad ratings given to this seller by their customers
@@ -53,8 +50,6 @@ public:
 	unsigned int get_total_ratings() const; // same as get_ratings_count
 	unsigned int get_reputation() const; // returns a percentage of good ratings
 	static std::vector<unsigned int> get_top_rated_sellers(unsigned int limit = 50); // returns a container of n seller_ids with the most positive (good) ratings // the default value of n is 50
-	// getters - wallet-related stuff
-	neroshop::Wallet * get_wallet() const;
 	// getters - order-related stuff
     unsigned int get_customer_order(unsigned int index) const;
     unsigned int get_customer_order_count() const;
@@ -77,8 +72,6 @@ public:
 	bool has_listed(const neroshop::Product& item) const; // returns true if this seller has listed an item
 	bool has_stock(const std::string& product_id) const; // returns true if this seller has an item in stock
 	bool has_stock(const neroshop::Product& item) const;
-	bool has_wallet() const; // returns true if seller's wallet is opened
-	bool has_wallet_synced() const; // returns true if seller's wallet is synced to a node
 	// callbacks
 	static neroshop::User * on_login(const neroshop::Wallet& wallet);
 	void on_order_received(std::string& subaddress);
@@ -87,7 +80,6 @@ public:
 protected:
     void load_customer_orders(); // called one-time when seller logs in
 private:
-	std::unique_ptr<neroshop::Wallet> wallet;
 	std::vector<int> customer_order_list;
 	friend class Serializer;
 };

--- a/src/core/user.hpp
+++ b/src/core/user.hpp
@@ -14,6 +14,7 @@ enum class UserAccountType : unsigned int { Guest, Buyer, Seller };
 
 namespace neroshop {
 
+class Wallet;
 class Cart; // forward declaration
 
 class User { // base class of seller and buyer // sellers can buy and sell while buyers (including guests) can only buy but cannot sell
@@ -45,8 +46,12 @@ public:
     // setters
     void set_public_key(const std::string& public_key);
     void set_private_key(const std::string& private_key);
+	// setters - wallet-related stuff
+	void set_wallet(const neroshop::Wallet& wallet);
     // getters
     std::string get_public_key() const;
+	// getters - wallet-related stuff
+	neroshop::Wallet * get_wallet() const;
     // account-related stuff - getters
     std::string get_id() const;//unsigned int get_id() const;
     std::string get_name() const;
@@ -74,6 +79,8 @@ public:
     // item-related stuff - boolean
     bool has_purchased(const std::string& listing_key); // checks if an item was previously purchased or not
     bool has_favorited(const std::string& listing_key); // checks if an item is in a user's favorites or wishlist
+	bool has_wallet() const; // returns true if seller's wallet is opened
+	bool has_wallet_synced() const; // returns true if seller's wallet is synced to a node
     // callbacks
     void on_registration(const std::string& name); // on registering an account
     //virtual User * on_login(const std::string& username);// = 0; // load all data: orders, reputation/ratings, settings // for all users
@@ -94,6 +101,7 @@ protected: // can only be accessed by classes that inherit from class User (even
     void load_cart();
     void load_orders(); // on login, load all orders this user has made so far (this function is called only once per login)
     void load_favorites(); // on login, load favorites (this function is called only once per login)
+	std::unique_ptr<neroshop::Wallet> wallet;
 private:
     std::string id;
     std::string name;


### PR DESCRIPTION
* `Node::set()` checks that all modified data have been re-signed and contain an updated signature.
* seller ratings can now be updated and self-verified.