### PR TITLE
memory-related bug fixes

### DIFF
--- a/src/core/market/seller.cpp
+++ b/src/core/market/seller.cpp
@@ -688,7 +688,7 @@ neroshop::User * Seller::on_login(const neroshop::Wallet& wallet) { // assumes u
     // set user properties retrieved from database
     dynamic_cast<Seller *>(user)->set_logged(true); // protected, so can only be accessed by child class obj    
     dynamic_cast<Seller *>(user)->set_id(monero_primary_address);
-    dynamic_cast<Seller *>(user)->set_wallet(wallet);
+    dynamic_cast<Seller *>(user)->set_wallet(&wallet);
     dynamic_cast<Seller *>(user)->set_account_type(UserAccountType::Seller);
     //-------------------------------
     /*// load orders
@@ -703,7 +703,7 @@ neroshop::User * Seller::on_login(const neroshop::Wallet& wallet) { // assumes u
 }
 ////////////////////
 void Seller::on_order_received(std::string& subaddress) {
-    if(!wallet.get()) throw std::runtime_error("wallet has not been initialized");
+    if(!wallet) throw std::runtime_error("wallet has not been initialized");
     if(!wallet->get_monero_wallet()) throw std::runtime_error("monero_wallet_full is not opened");
     // TODO: check if order type is a direct pay/no escrow before generating a new subaddress
     // if wallet is not properly synced with the daemon, you can only generate used addresses

--- a/src/core/market/user.cpp
+++ b/src/core/market/user.cpp
@@ -30,12 +30,12 @@ User::~User()
     private_key.clear();
     // destroy cart
     if(cart.get()) cart.reset();
-    // destroy wallet
-    if(wallet.get()) wallet.reset();
+    // don't reset wallet since we do not own it - WalletManager owns it, so just nullify it
+    wallet = nullptr;
     // clear orders
-    order_list.clear(); // this should reset (delete) all orders
+    order_list.clear();
     // clear favorites
-    favorites.clear(); // this should reset (delete) all favorites
+    favorites.clear();
 #ifdef NEROSHOP_DEBUG
     std::cout << "user deleted\n";
 #endif    
@@ -503,9 +503,8 @@ void User::set_private_key(const std::string& private_key) {
     this->private_key = private_key;
 }
 ////////////////////
-void User::set_wallet(const neroshop::Wallet& wallet) {
-    std::unique_ptr<neroshop::Wallet> user_wallet(&const_cast<neroshop::Wallet&>(wallet));
-    this->wallet = std::move(user_wallet);
+void User::set_wallet(const neroshop::Wallet* wallet) {
+    this->wallet = const_cast<neroshop::Wallet*>(wallet);  // just store pointer, do NOT wrap in unique_ptr
 }
 ////////////////////
 ////////////////////
@@ -574,7 +573,7 @@ std::string User::get_private_key() const {
 }
 ////////////////////
 neroshop::Wallet * User::get_wallet() const {
-    return wallet.get();
+    return wallet;
 }
 ////////////////////
 ////////////////////
@@ -750,7 +749,7 @@ bool User::has_favorited(const std::string& listing_key) {
 }
 ////////////////////
 bool User::has_wallet() const {
-    if(!wallet.get()) return false; // wallet is nullptr
+    if(!wallet) return false; // wallet is nullptr
     if(!wallet->get_monero_wallet()) return false; // wallet not opened
     return true;
 }

--- a/src/core/market/user.hpp
+++ b/src/core/market/user.hpp
@@ -49,7 +49,7 @@ public:
     void set_public_key(const std::string& public_key);
     void set_private_key(const std::string& private_key);
 	// setters - wallet-related stuff
-	void set_wallet(const neroshop::Wallet& wallet);
+	void set_wallet(const neroshop::Wallet* wallet);
     // getters
     std::string get_public_key() const;
 	// getters - wallet-related stuff
@@ -105,7 +105,8 @@ protected: // can only be accessed by classes that inherit from class User (even
     void load_cart();
     void load_orders(); // on login, load all orders this user has made so far (this function is called only once per login)
     void load_favorites(); // on login, load favorites (this function is called only once per login)
-	std::unique_ptr<neroshop::Wallet> wallet;
+	// Make wallet a non-owning raw pointer or maybe use std::weak_ptr if shared ownership is needed
+	neroshop::Wallet* wallet;
 private:
     std::string id;
     std::string name;

--- a/src/gui/currency_rate_provider.cpp
+++ b/src/gui/currency_rate_provider.cpp
@@ -74,10 +74,15 @@ CurrencyExchangeRatesProvider::~CurrencyExchangeRatesProvider()
     mUpdateFutureWatcher.waitForFinished();
 }
 
-QObject *CurrencyExchangeRatesProvider::qmlInstance(QQmlEngine * /*engine*/,
-                                                    QJSEngine * /*scriptEngine*/)
+QObject *CurrencyExchangeRatesProvider::qmlInstance(QQmlEngine * engine,
+                                                    QJSEngine * scriptEngine)
 {
-    return CurrencyExchangeRatesProvider::instance();
+    Q_UNUSED(engine)
+    Q_UNUSED(scriptEngine)
+    CurrencyExchangeRatesProvider *inst = CurrencyExchangeRatesProvider::instance();
+    // Tell QML engine not to delete this instance. Qt assumes ownership by default otherwise.
+    QQmlEngine::setObjectOwnership(inst, QQmlEngine::CppOwnership);
+    return inst;
 }
 
 CurrencyExchangeRatesProvider* CurrencyExchangeRatesProvider::instance() {


### PR DESCRIPTION
- use non-owning raw pointer (`neroshop::Wallet*`) for `User::wallet`
- prevent `CurrencyExchangeRatesProvider::instance()` from being freed more than once